### PR TITLE
Bugfix: atributos não encontrados

### DIFF
--- a/design/src/main/res/values/attrs.xml
+++ b/design/src/main/res/values/attrs.xml
@@ -106,8 +106,8 @@
         <attr name="ds_type" />
         <attr name="buttonTheme" />
         <attr name="isThemed" />
-        <attr name="isLink" />
-        <attr name="isTextAllCaps" />
+        <attr name="isLink" format="boolean" />
+        <attr name="isTextAllCaps" format="boolean" />
         <attr name="alignment" />
     </declare-styleable>
 


### PR DESCRIPTION
### Bug de compilação por aplicativos relacionados
Foi encontrado um erro em produção onde dois atributos do componente _DSButton_ não estavam corretamente declarados. 
- Foi informado o formato correto dos atributos para solucionar esse problema.