### PR TITLE
[ING-822] BUG: DSEditText colocando o cursor em local incorreto

### DIFF
--- a/design/src/main/java/com/ingresse/design/ui/editText/DSEditText.kt
+++ b/design/src/main/java/com/ingresse/design/ui/editText/DSEditText.kt
@@ -122,13 +122,15 @@ class DSEditText(context: Context, private val attributes: AttributeSet): FrameL
             if (!editText.hasFocus()) animateHintToCenter()
         }
 
-        if (wrongWhenEmpty && txt.isNullOrEmpty()) setEditTextError()
+        if (wrongWhenEmpty && txt.isNullOrEmpty()) return setEditTextError()
 
-        if (txt.isNullOrEmpty()) return
         animateHintToTop(animated)
         editText.setText(txt)
-        editText.setSelection(txt.length - 1)
         setEditTextDefault()
+
+        val currentText = editText.text
+        if (currentText.isNullOrEmpty()) return
+        editText.setSelection(currentText.length - 1)
     }
 
     fun getTextDS(): String = editText.text.toString()


### PR DESCRIPTION
## Descrição:
O DSEditText do _design systems_ após inserir o texto no componente tentava colocar o cursor no fim do texto, porém quando o texto era formatado, o valor do texto inicial era diferente do valor do texto contido no componente, então ao tentar buscar por um _index_ ele não encontrava, pois o texto era menor.

### Link do report: [FIREBASE](https://console.firebase.google.com/project/ingresse-a1350/crashlytics/app/android:com.ingresse.ticketbooth/issues/90a16222a10923c8ec5b75e92e3bafe5?utm_campaign=extensions&utm_medium=jira&utm_source=crashlytics_console_manual_issue)

### Link da issue: [JIRA - ING 822](https://ingresse.atlassian.net/browse/ING-822)

## Solução:
Agora para colocar o cursor no fim do texto, pegamos o texto do componente e não mais o texto inicial, e então teremos certeza da quantidade de letras no componente para colocar o curso no _index_ correto.