### PR TITLE
[DEV-244][DEV-247] Infra: remoção do jCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,7 @@
 buildscript {
     repositories {
-        mavenCentral()
-        jcenter()
         google()
+        mavenCentral()
     }
 
     dependencies {
@@ -13,9 +12,8 @@ buildscript {
 
 allprojects {
     repositories {
-        mavenCentral()
-        jcenter()
-        maven { url "https://www.jitpack.io" }
         google()
+        maven { url "https://www.jitpack.io" }
+        mavenCentral()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
+        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32"
     }
 }
 

--- a/design/build.gradle
+++ b/design/build.gradle
@@ -37,10 +37,10 @@ dependencies {
     implementation "com.google.android.material:material:1.3.0"
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.4.31"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.4.32"
 
     // GLIDE
-    implementation "jp.wasabeef:glide-transformations:3.3.0"
-    implementation "com.github.bumptech.glide:glide:4.9.0"
-    kapt "com.github.bumptech.glide:compiler:4.9.0"
+    implementation "jp.wasabeef:glide-transformations:4.3.0"
+    implementation "com.github.bumptech.glide:glide:4.12.0"
+    kapt "com.github.bumptech.glide:compiler:4.12.0"
 }


### PR DESCRIPTION
## Contexto:
Enfrentamos alguns problemas recentes com o tempo de _build_ da aplicação. Junto com isso veio o aviso da atualização de serviço do [JCenter](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) e todos os problemas que encontrávamos nas sincronizações do _gradle_ tinham relação com bibliotecas antigas que estavam sendo distribuídas por lá. Com base nisso precisamos remover todas essas dependências e atualizar bibliotecas para o uso mais recente com _mavenCentral_.

### Google warning: https://developer.android.com/studio/build/jcenter-migration
### Issue: https://ingresse.atlassian.net/browse/DEV-244

#### O que foi feito:
- Atualização do _gradle_ para 4.1.3 e _plugin_ para 1.4.32;
- Remoção das dependencias JCenter;
- Atualização das bibliotecas que migraram de serviço.