### PR TITLE
[Feature] Adição de troca de estilo de botão bordered

### DIFF
--- a/design/src/main/java/com/ingresse/design/ui/button/DSButton.kt
+++ b/design/src/main/java/com/ingresse/design/ui/button/DSButton.kt
@@ -22,7 +22,7 @@ class DSButton(context: Context, attrs: AttributeSet): AppCompatButton(context, 
     private val isThemed: Boolean
     private val isLink: Boolean
     private val isTextAllCaps: Boolean
-    private val isBordered: Boolean
+    private var isBordered: Boolean
 
     private val resHelper = ResourcesHelper(context)
     private val colorHelper = ColorHelper(context)
@@ -90,7 +90,7 @@ class DSButton(context: Context, attrs: AttributeSet): AppCompatButton(context, 
         setBackgroundResource(R.drawable.ds_stroked_button_bg)
         setTextColor(color)
         (background as LayerDrawable).apply {
-            getDrawable(0).setColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN)
+            getDrawable(0).setColorFilter(Color.TRANSPARENT, PorterDuff.Mode.SRC_IN)
             getDrawable(1).setColorFilter(color, PorterDuff.Mode.SRC_IN)
         }
     }
@@ -131,5 +131,10 @@ class DSButton(context: Context, attrs: AttributeSet): AppCompatButton(context, 
     fun setStyle(buttonType: ButtonType) {
         style = buttonType
         setupStyle()
+    }
+
+    fun setBordered() {
+        isBordered = true
+        setBorderedButton()
     }
 }


### PR DESCRIPTION
## Contexto:
Havia uma necessidade de adicionar o cenário de estilo de botão conhecido como bordered, na qual trabalha com o fundo transparente e sua borda e fonte na cor escolhida.

### O que foi feito:

- Função para alterar o estilo de botão;
- Troca do fundo do botão tipo _bordered_ para transparente.